### PR TITLE
vscode support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ project/.sbtserver
 
 # Application
 learn-duel.log
+
+#Ensime
+.ensime
+.ensime_cache/
+ensime-langserver.log
+pc.stdout.log

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,7 +27,7 @@
         {
             "label": "run",
             "type": "shell",
-            "command": "sbt 'run -Dhttps.port=9443 -Dhttp.port=disabled'"
+            "command": "sbt run"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+    "version": "2.0.0",
+    "command": "sbt",
+    "type": "shell",
+    "presentation": {
+        "reveal": "always"
+    },
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "sbt compile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "test",
+            "type": "shell",
+            "command": "sbt test",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "run",
+            "type": "shell",
+            "command": "sbt 'run -Dhttps.port=9443 -Dhttp.port=disabled'"
+        }
+    ]
+}


### PR DESCRIPTION
The VSCode plugin Scala Language Server based on Ensime produces a lot of cache-files and need a config-file. I added these files to the .gitignore.  